### PR TITLE
fix: create dynamodb table

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -5,7 +5,8 @@ terraform {
     bucket         = "myawsbucket-s3-ada" #"myawsbucket-s3-ada" #bucket para arquivo do terraform
     key            = "terraform/terraform.tfstate"
     region         = "us-east-1"
-    dynamodb_table = "upreports-tabela-dynamodb-para-lock"
+    dynamodb_table = "aws_dynamodb_table.terraform_state_lock.name"
+    
   }
 }
 


### PR DESCRIPTION
Criando a tabela dynamodb.

Ref: Sem a tabela DynamoDB especificada, o Terraform usará um arquivo de travamento local para bloquear o estado durante operações de escrita. No entanto, tenha em mente que o travamento de estado com um arquivo local pode não ser ideal em ambientes compartilhados, onde várias instâncias do Terraform podem estar sendo executadas simultaneamente. Nesses casos, é altamente recomendável usar uma tabela DynamoDB para travamento de estado.